### PR TITLE
Fix typo and deprecated values

### DIFF
--- a/tasks/setup-Archlinux.yml
+++ b/tasks/setup-Archlinux.yml
@@ -1,6 +1,6 @@
 ---
 - pacman:
     name: nftables
-    state: installed
+    state: present
     update_cache: yes
 ...

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - apt:
     name: nftables
-    state: installed
+    state: present
     update_cache: yes
 ...

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - yum:
     name: nftables
-    state: installed
+    state: present
     update_cache: yes
 ... 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 ---
-nftables_config_file: /etc/ntfables.conf
+nftables_config_file: /etc/nftables.conf
 ...


### PR DESCRIPTION
- `state: installed` is deprecated. Using `present` instead.
- `ntfables.conf` -> `nftables.conf`.