### PR TITLE
Fix variable names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nft_flush_ruleset: yes
-nft_config_file: "/etc/sysconfig/nftables.conf"
-nft_tables: []
+nftables_flush_ruleset: yes
+nftables_config_file: "/etc/nftables.conf"
+nftables_tables: []
 ...

--- a/templates/nftables.rules.j2
+++ b/templates/nftables.rules.j2
@@ -2,11 +2,11 @@
 #!/usr/sbin/nft -f
 {{ ansible_managed | comment }}
 
-{% if nft_flush_ruleset %}
+{% if nftables_flush_ruleset %}
 flush ruleset
 {% endif %}
 
-{% for table in nft_tables %}
+{% for table in nftables_tables %}
 table {{ table.family }} {{ table.name }} {
 
 {%- if table.sets is defined %}


### PR DESCRIPTION
I almost missed the errors.

Variable names are fixed.
Also, the default value of `nftables_config_file` is changed to be consistent with the readme.